### PR TITLE
GitButler Integration Commit

### DIFF
--- a/contracts/squares/square.ral
+++ b/contracts/squares/square.ral
@@ -1,0 +1,19 @@
+// The child contract for the PARENT contract SQUARES.ral
+Contract Square (
+    parentcontract: ByteVec,                                    // the id of the parent contract
+    owner: Address,
+    timecreated: U256,
+    upgradefee: U256,
+    size: U256,
+    image: U256,
+    description: ByteVec
+) {
+    // Events
+    event updatedimage(updatedimg: ByteVec, timedone: U256)
+
+    // Error Codes
+
+    // Functions
+
+    // Contract Functions
+}

--- a/contracts/squares/squares.ral
+++ b/contracts/squares/squares.ral
@@ -1,0 +1,18 @@
+// The parent contract for Square
+Contract Squares (
+    contract: ByteVec,
+    dev: Address,
+    lead: Address,
+    maxsquares: U256,
+    currentsquares: U256,
+    ngutoken: ByteVec,
+    ngufee: U256
+) {
+    // Events
+
+    // Error Codes
+
+    // Functions
+
+    // Contract Functions
+}


### PR DESCRIPTION
This is an integration commit for the virtual branches that GitButler is tracking.

Due to GitButler managing multiple virtual branches, you cannot switch back and forth between git branches and virtual branches easily. 

If you switch to another branch, GitButler will need to be reinitialized. If you commit on this branch, GitButler will throw it away.

Here are the branches that are currently applied:
 - Add squares contract (refs/gitbutler/Add-squares-contract) branch head: 386bbc0c8bd25522a6c95d4f4a559482023350fe
   - contracts/squares/square.ral
   - contracts/squares/squares.ral

Your previous branch was: refs/heads/swaps-and-auctions

The sha for that commit was: 0f2104ea2ada62e3a62185632806d68026ac8404

For more information about what we're doing here, check out our docs: https://docs.gitbutler.com/features/virtual-branches/integration-branch